### PR TITLE
Use [[maybe_unused]] on unused allocator parameter to suppress -Wunused-parameter warning

### DIFF
--- a/include/dro/spsc-queue.hpp
+++ b/include/dro/spsc-queue.hpp
@@ -96,7 +96,7 @@ struct StackBuffer {
   std::array<T, capacity_ + (2 * padding)> buffer_;
 
   explicit StackBuffer(const std::size_t capacity,
-                       const Allocator &allocator = Allocator()) {
+                       [[maybe_unused]] const Allocator &allocator = Allocator()) {
     if (capacity) {
       throw std::invalid_argument(
           "Capacity in constructor is ignored for stack allocations");


### PR DESCRIPTION
Great implementation. I ran a few (incredibly hacky) benchmarks against rigtorp myself and this looks to be significantly faster, so I've decided to use this one in my project. 

I ran into a small build error when testing the Stack-allocated queue with the -Werror and -Wunused-parameter flags.

```
dro/spsc-queue.hpp:99:41: error: unused parameter 'allocator' [-Werror,-Wunused-parameter]
   99 |                        const Allocator &allocator = Allocator()) {
      |                                         ^
```

I understand that both heap and stack based buffers need the same constructor, so I think the most elegant solution is to let the compiler know this is an intentionally unused arg, as this warning will leak into all projects using this otherwise.

P.S. would really love some benchmarks of the Heap vs Stack based implementations, as it's interesting to reason about the two and which one is faster (and in which cases). I'd think stack is faster but my benchmarks show a different story, so would be nice to get some verified and legit numbers.